### PR TITLE
upgrade rxjs to version 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6636,12 +6636,20 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
-      "integrity": "sha1-KNQD8AcRIZZ/GK1mVWMlXVQjasM=",
+      "version": "6.0.0",
+      "resolved": "http://tulnuget.cimarex.local:81/npm/npm/rxjs/-/rxjs-6.0.0.tgz",
+      "integrity": "sha512-2MgLQr1zvks8+Kip4T6hcJdiBhV+SIvxguoWjhwtSpNPTp/5e09HJbgclCwR/nW0yWzhubM+6Q0prl8G5RuoBA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.4"
+        "tslib": "1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "http://tulnuget.cimarex.local:81/npm/npm/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha1-43qG/ajLuvI6BX9HPJ9Nxk5fwug=",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -7312,12 +7320,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
-    "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
       "dev": true
     },
     "systemjs": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "protractor": "~5.1.0",
     "rollup": "^0.49.3",
     "run-sequence": "^1.2.2",
-    "rxjs": "^5.1.0",
+    "rxjs": "^6.0.0",
     "systemjs": "^0.20.12",
     "ts-node": "~2.0.0",
     "tslint": "~4.5.0",

--- a/src/ajax-http-client-adapter.ts
+++ b/src/ajax-http-client-adapter.ts
@@ -1,7 +1,6 @@
 import { HttpClient, HttpHeaders, HttpRequest, HttpEvent, HttpResponse, HttpErrorResponse } from "@angular/common/http";
 import { core, HttpResponse as BreezeHttpResponse } from "breeze-client";
-import { filter } from "rxjs/operators/filter";
-import { map } from "rxjs/operators/map";
+import { filter,  map } from "rxjs/operators";
 
 import { DsaConfig } from "./common";
 


### PR DESCRIPTION
Upgrade rxjs dependency to version 6 so that the rxjs-compat package is not required for applications using version 6.